### PR TITLE
Add the ability to make custom categories for GameRules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 	mappings "net.fabricmc:yarn:${project.minecraft_version}+build.${project.yarn_build}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	//modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-	// compileOnly "com.google.code.findbugs:jsr305:3.0.2" //TODO: what are we going to do for annotations?
+	 compileOnly "com.google.code.findbugs:jsr305:3.0.2" //TODO: what are we going to do for annotations?
 }
 
 checkstyle {

--- a/src/main/java/io/github/fablabsmc/fablabs/api/gamerule/v1/FabricGameRuleCategory.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/gamerule/v1/FabricGameRuleCategory.java
@@ -1,32 +1,33 @@
 package io.github.fablabsmc.fablabs.api.gamerule.v1;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
+import net.minecraft.util.Formatting;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 
 /**
- * Utility class for registering GameRule objects with custom categories outside of the seven categories MC provides
+ * Utility class for registering GameRule objects with custom categories outside of the categories MC provides.
  */
-public class FabricGameRuleCategory implements Comparable<FabricGameRuleCategory>{
-    private final Text category;
+public class FabricGameRuleCategory implements Comparable<FabricGameRuleCategory> {
+	private final Text category;
 
-    public FabricGameRuleCategory(String category) {
-        this.category = new LiteralText(category).styled((style) -> style.withBold(true).withColor(Formatting.YELLOW));
-    }
+	public FabricGameRuleCategory(String category) {
+		this.category = new LiteralText(category).styled((style) -> style.withBold(true).withColor(Formatting.YELLOW));
+	}
 
-    public FabricGameRuleCategory(Text category) {
-        this.category = category;
-    }
+	public FabricGameRuleCategory(Text category) {
+		this.category = category;
+	}
 
-    @Environment(EnvType.CLIENT)
-    public Text getName() {
-        return this.category;
-    }
+	@Environment(EnvType.CLIENT)
+	public Text getName() {
+		return this.category;
+	}
 
-    @Override
-    public int compareTo(FabricGameRuleCategory category) {
-        return this.category.asString().compareTo(category.category.asString());
-    }
+	@Override
+	public int compareTo(FabricGameRuleCategory category) {
+		return this.category.asString().compareTo(category.category.asString());
+	}
 }

--- a/src/main/java/io/github/fablabsmc/fablabs/api/gamerule/v1/FabricGameRuleCategory.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/gamerule/v1/FabricGameRuleCategory.java
@@ -1,33 +1,26 @@
 package io.github.fablabsmc.fablabs.api.gamerule.v1;
 
-import net.minecraft.util.Formatting;
-import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
-
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
+import net.minecraft.util.Identifier;
 
 /**
- * Utility class for registering GameRule objects with custom categories outside of the categories MC provides.
+ * Utility class for registering GameRule objects with custom categories outside of the categories Minecraft provides.
  */
 public class FabricGameRuleCategory implements Comparable<FabricGameRuleCategory> {
-	private final Text category;
+	private final Identifier id;
+	private final Text name;
 
-	public FabricGameRuleCategory(String category) {
-		this.category = new LiteralText(category).styled((style) -> style.withBold(true).withColor(Formatting.YELLOW));
+	public FabricGameRuleCategory(Identifier id, Text name) {
+		this.id = id;
+		this.name = name;
 	}
 
-	public FabricGameRuleCategory(Text category) {
-		this.category = category;
-	}
-
-	@Environment(EnvType.CLIENT)
 	public Text getName() {
-		return this.category;
+		return this.name;
 	}
 
 	@Override
 	public int compareTo(FabricGameRuleCategory category) {
-		return this.category.asString().compareTo(category.category.asString());
+		return this.id.compareTo(category.id);
 	}
 }

--- a/src/main/java/io/github/fablabsmc/fablabs/api/gamerule/v1/FabricGameRuleCategory.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/gamerule/v1/FabricGameRuleCategory.java
@@ -1,0 +1,32 @@
+package io.github.fablabsmc.fablabs.api.gamerule.v1;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+/**
+ * Utility class for registering GameRule objects with custom categories outside of the seven categories MC provides
+ */
+public class FabricGameRuleCategory implements Comparable<FabricGameRuleCategory>{
+    private final Text category;
+
+    public FabricGameRuleCategory(String category) {
+        this.category = new LiteralText(category).styled((style) -> style.withBold(true).withColor(Formatting.YELLOW));
+    }
+
+    public FabricGameRuleCategory(Text category) {
+        this.category = category;
+    }
+
+    @Environment(EnvType.CLIENT)
+    public Text getName() {
+        return this.category;
+    }
+
+    @Override
+    public int compareTo(FabricGameRuleCategory category) {
+        return this.category.asString().compareTo(category.category.asString());
+    }
+}

--- a/src/main/java/io/github/fablabsmc/fablabs/api/gamerule/v1/GameRuleRegistry.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/gamerule/v1/GameRuleRegistry.java
@@ -1,15 +1,12 @@
 package io.github.fablabsmc.fablabs.api.gamerule.v1;
 
-import java.util.HashMap;
-
+import io.github.fablabsmc.fablabs.impl.gamerule.RuleCategories;
 import io.github.fablabsmc.fablabs.mixin.gamerule.GameRulesAccessor;
 
 import net.minecraft.util.Identifier;
 import net.minecraft.world.GameRules;
 
 public final class GameRuleRegistry {
-	public static final HashMap<GameRules.RuleKey<?>, FabricGameRuleCategory> MAP = new HashMap<>();
-
 	private GameRuleRegistry() {
 	}
 
@@ -39,7 +36,7 @@ public final class GameRuleRegistry {
 	 */
 	public static <T extends GameRules.Rule<T>> GameRules.RuleKey<T> register(Identifier id, FabricGameRuleCategory category, GameRules.RuleType<T> type) {
 		GameRules.RuleKey<T> key = GameRulesAccessor.invokeRegister(id.toString(), GameRules.RuleCategory.MISC, type);
-		MAP.putIfAbsent(key, category);
+		RuleCategories.putIfAbsent(key, category);
 		return key;
 	}
 }

--- a/src/main/java/io/github/fablabsmc/fablabs/api/gamerule/v1/GameRuleRegistry.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/gamerule/v1/GameRuleRegistry.java
@@ -1,11 +1,14 @@
 package io.github.fablabsmc.fablabs.api.gamerule.v1;
 
 import io.github.fablabsmc.fablabs.mixin.gamerule.GameRulesAccessor;
-
 import net.minecraft.util.Identifier;
 import net.minecraft.world.GameRules;
 
+import java.util.HashMap;
+
 public final class GameRuleRegistry {
+	public static final HashMap<GameRules.RuleKey<?>, FabricGameRuleCategory> MAP = new HashMap<>();
+
 	private GameRuleRegistry() {
 	}
 
@@ -13,13 +16,29 @@ public final class GameRuleRegistry {
 	 * Registers a {@link GameRules.Rule}.
 	 *
 	 * @param id   the id this rule will be named
-	 * @param category the category of this rule.
+	 * @param category the category of this rule
 	 * @param type the rule type
 	 * @param <T>  the type of rule
 	 * @return a rule key which can be used to query the value of the rule
-	 * @throws IllegalStateException if a rule of the same name already exists.
+	 * @throws IllegalStateException if a rule of the same name already exists
 	 */
 	public static <T extends GameRules.Rule<T>> GameRules.RuleKey<T> register(Identifier id, GameRules.RuleCategory category, GameRules.RuleType<T> type) {
 		return GameRulesAccessor.invokeRegister(id.toString(), category, type);
+	}
+
+	/**
+	 * Registers a {@link GameRules.Rule} with a custom category.
+	 *
+	 * @param id 	the id this rule will be named
+	 * @param category the category of this rule
+	 * @param type the rule type
+	 * @param <T>  the type of rule
+	 * @return a rule key which can be used to query the value of the rule
+	 * @throws IllegalStateException if a rule of the same name already exists
+	 */
+	public static <T extends GameRules.Rule<T>> GameRules.RuleKey<T> register(Identifier id, FabricGameRuleCategory category, GameRules.RuleType<T> type) {
+		GameRules.RuleKey<T> key = GameRulesAccessor.invokeRegister(id.toString(), GameRules.RuleCategory.MISC, type);
+		MAP.putIfAbsent(key, category);
+		return key;
 	}
 }

--- a/src/main/java/io/github/fablabsmc/fablabs/api/gamerule/v1/GameRuleRegistry.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/api/gamerule/v1/GameRuleRegistry.java
@@ -1,10 +1,11 @@
 package io.github.fablabsmc.fablabs.api.gamerule.v1;
 
+import java.util.HashMap;
+
 import io.github.fablabsmc.fablabs.mixin.gamerule.GameRulesAccessor;
+
 import net.minecraft.util.Identifier;
 import net.minecraft.world.GameRules;
-
-import java.util.HashMap;
 
 public final class GameRuleRegistry {
 	public static final HashMap<GameRules.RuleKey<?>, FabricGameRuleCategory> MAP = new HashMap<>();

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/gamerule/RuleCategories.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/gamerule/RuleCategories.java
@@ -1,0 +1,23 @@
+package io.github.fablabsmc.fablabs.impl.gamerule;
+
+import java.util.HashMap;
+
+import io.github.fablabsmc.fablabs.api.gamerule.v1.FabricGameRuleCategory;
+
+import net.minecraft.world.GameRules;
+
+public class RuleCategories {
+	private static final HashMap<GameRules.RuleKey<?>, FabricGameRuleCategory> MAP = new HashMap<>();
+
+	public static void putIfAbsent(GameRules.RuleKey<?> key, FabricGameRuleCategory value) {
+		MAP.putIfAbsent(key, value);
+	}
+
+	public static boolean containsKey(GameRules.RuleKey<?> key) {
+		return MAP.containsKey(key);
+	}
+
+	public static FabricGameRuleCategory get(GameRules.RuleKey<?> key) {
+		return MAP.get(key);
+	}
+}

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/gamerule/TestRules.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/gamerule/TestRules.java
@@ -1,20 +1,22 @@
 package io.github.fablabsmc.fablabs.impl.gamerule;
 
+import java.util.Arrays;
+
 import io.github.fablabsmc.fablabs.api.gamerule.v1.FabricGameRuleCategory;
 import io.github.fablabsmc.fablabs.api.gamerule.v1.GameRuleRegistry;
 import io.github.fablabsmc.fablabs.api.gamerule.v1.RuleFactory;
 import io.github.fablabsmc.fablabs.api.gamerule.v1.rule.DoubleRule;
 import io.github.fablabsmc.fablabs.api.gamerule.v1.rule.EnumRule;
 import io.github.fablabsmc.fablabs.api.gamerule.v1.rule.FloatRule;
-import net.fabricmc.api.ModInitializer;
-import net.fabricmc.loader.api.FabricLoader;
+
 import net.minecraft.text.LiteralText;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.GameRules;
 
-import java.util.Arrays;
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.loader.api.FabricLoader;
 
 @Deprecated
 public class TestRules implements ModInitializer {
@@ -37,27 +39,28 @@ public class TestRules implements ModInitializer {
 			register("green_bool", GREEN_CATEGORY, RuleFactory.createBooleanRule(false));
 
 	public static final GameRules.RuleKey<GameRules.BooleanRule> TEST_BOOL_RED =
-			register( "red_bool", RED_CATEGORY, RuleFactory.createBooleanRule(false));
+			register("red_bool", RED_CATEGORY, RuleFactory.createBooleanRule(false));
 
 	public static final GameRules.RuleKey<EnumRule<Direction>> TEST_ENUM_RED =
 			register("red_enum", RED_CATEGORY, RuleFactory.createEnumRule(Direction.NORTH));
-
 
 	@Override
 	public void onInitialize() {
 	}
 
 	private static <T extends GameRules.Rule<T>> GameRules.RuleKey<T> register(String path, GameRules.RuleCategory category, GameRules.RuleType<T> type) {
-		if (FabricLoader.getInstance().isDevelopmentEnvironment())
+		if (FabricLoader.getInstance().isDevelopmentEnvironment()) {
 			return GameRuleRegistry.register(new Identifier("test", path), category, type);
-		else
+		} else {
 			return null;
+		}
 	}
 
 	private static <T extends GameRules.Rule<T>> GameRules.RuleKey<T> register(String path, FabricGameRuleCategory category, GameRules.RuleType<T> type) {
-		if (FabricLoader.getInstance().isDevelopmentEnvironment())
+		if (FabricLoader.getInstance().isDevelopmentEnvironment()) {
 			return GameRuleRegistry.register(new Identifier("test", path), category, type);
-		else
+		} else {
 			return null;
+		}
 	}
 }

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/gamerule/TestRules.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/gamerule/TestRules.java
@@ -20,9 +20,11 @@ import net.fabricmc.loader.api.FabricLoader;
 
 @Deprecated
 public class TestRules implements ModInitializer {
-	public static final FabricGameRuleCategory GREEN_CATEGORY = new FabricGameRuleCategory(new LiteralText("This One is Green").styled(style -> style.withBold(true).withColor(Formatting.DARK_GREEN)));
+	public static final FabricGameRuleCategory GREEN_CATEGORY = new FabricGameRuleCategory(new Identifier("test", "green"),
+			new LiteralText("This One is Green").styled(style -> style.withBold(true).withColor(Formatting.DARK_GREEN)));
 
-	public static final FabricGameRuleCategory RED_CATEGORY = new FabricGameRuleCategory(new LiteralText("This One is Red").styled(style -> style.withBold(true).withColor(Formatting.DARK_RED)));
+	public static final FabricGameRuleCategory RED_CATEGORY = new FabricGameRuleCategory(new Identifier("test", "red"),
+			new LiteralText("This One is Red").styled(style -> style.withBold(true).withColor(Formatting.DARK_RED)));
 
 	public static final GameRules.RuleKey<GameRules.IntRule> TEST_INT_RULE = register("boundy", GameRules.RuleCategory.MISC, RuleFactory.createIntRule(2, 0));
 	public static final GameRules.RuleKey<DoubleRule> TEST_DOB = register("bound2", GameRules.RuleCategory.MISC, RuleFactory.createDoubleRule(1, 1.0D, 10.0D));

--- a/src/main/java/io/github/fablabsmc/fablabs/impl/gamerule/TestRules.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/impl/gamerule/TestRules.java
@@ -1,21 +1,27 @@
 package io.github.fablabsmc.fablabs.impl.gamerule;
 
-import java.util.Arrays;
-
+import io.github.fablabsmc.fablabs.api.gamerule.v1.FabricGameRuleCategory;
 import io.github.fablabsmc.fablabs.api.gamerule.v1.GameRuleRegistry;
 import io.github.fablabsmc.fablabs.api.gamerule.v1.RuleFactory;
 import io.github.fablabsmc.fablabs.api.gamerule.v1.rule.DoubleRule;
 import io.github.fablabsmc.fablabs.api.gamerule.v1.rule.EnumRule;
 import io.github.fablabsmc.fablabs.api.gamerule.v1.rule.FloatRule;
-
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.text.LiteralText;
+import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.GameRules;
 
-import net.fabricmc.api.ModInitializer;
+import java.util.Arrays;
 
 @Deprecated
 public class TestRules implements ModInitializer {
+	public static final FabricGameRuleCategory GREEN_CATEGORY = new FabricGameRuleCategory(new LiteralText("This One is Green").styled(style -> style.withBold(true).withColor(Formatting.DARK_GREEN)));
+
+	public static final FabricGameRuleCategory RED_CATEGORY = new FabricGameRuleCategory(new LiteralText("This One is Red").styled(style -> style.withBold(true).withColor(Formatting.DARK_RED)));
+
 	public static final GameRules.RuleKey<GameRules.IntRule> TEST_INT_RULE = register("boundy", GameRules.RuleCategory.MISC, RuleFactory.createIntRule(2, 0));
 	public static final GameRules.RuleKey<DoubleRule> TEST_DOB = register("bound2", GameRules.RuleCategory.MISC, RuleFactory.createDoubleRule(1, 1.0D, 10.0D));
 	public static final GameRules.RuleKey<FloatRule> TEST_FLOAT = register("bound3", GameRules.RuleCategory.MISC, RuleFactory.createFloatRule(0.0F, 0.0F, 1.0F));
@@ -27,11 +33,31 @@ public class TestRules implements ModInitializer {
 					.toArray(Direction[]::new)
 	));
 
+	public static final GameRules.RuleKey<GameRules.BooleanRule> TEST_BOOL_GREEN =
+			register("green_bool", GREEN_CATEGORY, RuleFactory.createBooleanRule(false));
+
+	public static final GameRules.RuleKey<GameRules.BooleanRule> TEST_BOOL_RED =
+			register( "red_bool", RED_CATEGORY, RuleFactory.createBooleanRule(false));
+
+	public static final GameRules.RuleKey<EnumRule<Direction>> TEST_ENUM_RED =
+			register("red_enum", RED_CATEGORY, RuleFactory.createEnumRule(Direction.NORTH));
+
+
 	@Override
 	public void onInitialize() {
 	}
 
 	private static <T extends GameRules.Rule<T>> GameRules.RuleKey<T> register(String path, GameRules.RuleCategory category, GameRules.RuleType<T> type) {
-		return GameRuleRegistry.register(new Identifier("test", path), category, type);
+		if (FabricLoader.getInstance().isDevelopmentEnvironment())
+			return GameRuleRegistry.register(new Identifier("test", path), category, type);
+		else
+			return null;
+	}
+
+	private static <T extends GameRules.Rule<T>> GameRules.RuleKey<T> register(String path, FabricGameRuleCategory category, GameRules.RuleType<T> type) {
+		if (FabricLoader.getInstance().isDevelopmentEnvironment())
+			return GameRuleRegistry.register(new Identifier("test", path), category, type);
+		else
+			return null;
 	}
 }

--- a/src/main/java/io/github/fablabsmc/fablabs/mixin/gamerule/client/EditGameRulesScreen$RuleListWidgetMixin.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/mixin/gamerule/client/EditGameRulesScreen$RuleListWidgetMixin.java
@@ -40,7 +40,7 @@ public abstract class EditGameRulesScreen$RuleListWidgetMixin extends ElementLis
         if (GameRuleRegistry.MAP.containsKey(entry.getKey())) {
             FabricGameRuleCategory category = GameRuleRegistry.MAP.get(entry.getKey());
             fabricCategories.putIfAbsent(category, new ArrayList<>());
-            fabricCategories.get(category).add(entry.getValue());
+            fabricCategories.computeIfAbsent(category, c -> new ArrayList<>()).add(entry.getValue());
             ci.cancel();
         }
     }

--- a/src/main/java/io/github/fablabsmc/fablabs/mixin/gamerule/client/EditGameRulesScreen$RuleListWidgetMixin.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/mixin/gamerule/client/EditGameRulesScreen$RuleListWidgetMixin.java
@@ -1,0 +1,47 @@
+package io.github.fablabsmc.fablabs.mixin.gamerule.client;
+
+import io.github.fablabsmc.fablabs.api.gamerule.v1.GameRuleRegistry;
+import io.github.fablabsmc.fablabs.api.gamerule.v1.FabricGameRuleCategory;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.world.EditGameRulesScreen;
+import net.minecraft.client.gui.widget.ElementListWidget;
+import net.minecraft.world.GameRules;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.TreeMap;
+
+@Mixin(targets = "net/minecraft/client/gui/screen/world/EditGameRulesScreen$RuleListWidget")
+public abstract class EditGameRulesScreen$RuleListWidgetMixin extends ElementListWidget<EditGameRulesScreen.AbstractRuleWidget> {
+    private EditGameRulesScreen$RuleListWidgetMixin(MinecraftClient minecraftClient, int i, int j, int k, int l, int m) {
+        super(minecraftClient, i, j, k, l, m);
+    }
+
+    private Map<FabricGameRuleCategory, ArrayList<EditGameRulesScreen.AbstractRuleWidget>> fabricCategories = new TreeMap<>();
+
+    @SuppressWarnings("InvalidInjectorMethodSignature")
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void initializeFabricGameruleCategories(EditGameRulesScreen screen, GameRules gameRules, CallbackInfo ci) {
+        fabricCategories.forEach((category, widgetList) -> {
+            this.addEntry(screen.new RuleCategoryWidget(category.getName()));
+            for (EditGameRulesScreen.AbstractRuleWidget widget : widgetList) {
+                this.addEntry(widget);
+            }
+        });
+    }
+
+    @SuppressWarnings("UnresolvedMixinReference")
+    @Inject(method = "method_27638(Ljava/util/Map$Entry;)V", at = @At("HEAD"), cancellable = true)
+    private void dontShowFabric(Map.Entry<GameRules.RuleKey<?>, EditGameRulesScreen.AbstractRuleWidget> entry, CallbackInfo ci) {
+        if (GameRuleRegistry.MAP.containsKey(entry.getKey())) {
+            FabricGameRuleCategory category = GameRuleRegistry.MAP.get(entry.getKey());
+            fabricCategories.putIfAbsent(category, new ArrayList<>());
+            fabricCategories.get(category).add(entry.getValue());
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/io/github/fablabsmc/fablabs/mixin/gamerule/client/EditGameRulesScreen$RuleListWidgetMixin.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/mixin/gamerule/client/EditGameRulesScreen$RuleListWidgetMixin.java
@@ -1,47 +1,49 @@
 package io.github.fablabsmc.fablabs.mixin.gamerule.client;
 
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.TreeMap;
+
 import io.github.fablabsmc.fablabs.api.gamerule.v1.GameRuleRegistry;
 import io.github.fablabsmc.fablabs.api.gamerule.v1.FabricGameRuleCategory;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.world.EditGameRulesScreen;
-import net.minecraft.client.gui.widget.ElementListWidget;
-import net.minecraft.world.GameRules;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.TreeMap;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.world.EditGameRulesScreen;
+import net.minecraft.client.gui.widget.ElementListWidget;
+import net.minecraft.world.GameRules;
 
 @Mixin(targets = "net/minecraft/client/gui/screen/world/EditGameRulesScreen$RuleListWidget")
 public abstract class EditGameRulesScreen$RuleListWidgetMixin extends ElementListWidget<EditGameRulesScreen.AbstractRuleWidget> {
-    private EditGameRulesScreen$RuleListWidgetMixin(MinecraftClient minecraftClient, int i, int j, int k, int l, int m) {
-        super(minecraftClient, i, j, k, l, m);
-    }
+	private EditGameRulesScreen$RuleListWidgetMixin(MinecraftClient minecraftClient, int i, int j, int k, int l, int m) {
+		super(minecraftClient, i, j, k, l, m);
+	}
 
-    private Map<FabricGameRuleCategory, ArrayList<EditGameRulesScreen.AbstractRuleWidget>> fabricCategories = new TreeMap<>();
+	private Map<FabricGameRuleCategory, ArrayList<EditGameRulesScreen.AbstractRuleWidget>> fabricCategories = new TreeMap<>();
 
-    @SuppressWarnings("InvalidInjectorMethodSignature")
-    @Inject(method = "<init>", at = @At("TAIL"))
-    private void initializeFabricGameruleCategories(EditGameRulesScreen screen, GameRules gameRules, CallbackInfo ci) {
-        fabricCategories.forEach((category, widgetList) -> {
-            this.addEntry(screen.new RuleCategoryWidget(category.getName()));
-            for (EditGameRulesScreen.AbstractRuleWidget widget : widgetList) {
-                this.addEntry(widget);
-            }
-        });
-    }
+	@SuppressWarnings("InvalidInjectorMethodSignature")
+	@Inject(method = "<init>", at = @At("TAIL"))
+	private void initializeFabricGameruleCategories(EditGameRulesScreen screen, GameRules gameRules, CallbackInfo ci) {
+		fabricCategories.forEach((category, widgetList) -> {
+			this.addEntry(screen.new RuleCategoryWidget(category.getName()));
 
-    @SuppressWarnings("UnresolvedMixinReference")
-    @Inject(method = "method_27638(Ljava/util/Map$Entry;)V", at = @At("HEAD"), cancellable = true)
-    private void dontShowFabric(Map.Entry<GameRules.RuleKey<?>, EditGameRulesScreen.AbstractRuleWidget> entry, CallbackInfo ci) {
-        if (GameRuleRegistry.MAP.containsKey(entry.getKey())) {
-            FabricGameRuleCategory category = GameRuleRegistry.MAP.get(entry.getKey());
-            fabricCategories.putIfAbsent(category, new ArrayList<>());
-            fabricCategories.get(category).add(entry.getValue());
-            ci.cancel();
-        }
-    }
+			for (EditGameRulesScreen.AbstractRuleWidget widget : widgetList) {
+				this.addEntry(widget);
+			}
+		});
+	}
+
+	@SuppressWarnings("UnresolvedMixinReference")
+	@Inject(method = "method_27638(Ljava/util/Map$Entry;)V", at = @At("HEAD"), cancellable = true)
+	private void dontShowFabric(Map.Entry<GameRules.RuleKey<?>, EditGameRulesScreen.AbstractRuleWidget> entry, CallbackInfo ci) {
+		if (GameRuleRegistry.MAP.containsKey(entry.getKey())) {
+			FabricGameRuleCategory category = GameRuleRegistry.MAP.get(entry.getKey());
+			fabricCategories.putIfAbsent(category, new ArrayList<>());
+			fabricCategories.get(category).add(entry.getValue());
+			ci.cancel();
+		}
+	}
 }

--- a/src/main/java/io/github/fablabsmc/fablabs/mixin/gamerule/client/EditGameRulesScreen$RuleListWidgetMixin.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/mixin/gamerule/client/EditGameRulesScreen$RuleListWidgetMixin.java
@@ -4,8 +4,8 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.TreeMap;
 
-import io.github.fablabsmc.fablabs.api.gamerule.v1.GameRuleRegistry;
 import io.github.fablabsmc.fablabs.api.gamerule.v1.FabricGameRuleCategory;
+import io.github.fablabsmc.fablabs.impl.gamerule.RuleCategories;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -22,7 +22,7 @@ public abstract class EditGameRulesScreen$RuleListWidgetMixin extends ElementLis
 		super(minecraftClient, i, j, k, l, m);
 	}
 
-	private Map<FabricGameRuleCategory, ArrayList<EditGameRulesScreen.AbstractRuleWidget>> fabricCategories = new TreeMap<>();
+	private final Map<FabricGameRuleCategory, ArrayList<EditGameRulesScreen.AbstractRuleWidget>> fabricCategories = new TreeMap<>();
 
 	@SuppressWarnings("InvalidInjectorMethodSignature")
 	@Inject(method = "<init>", at = @At("TAIL"))
@@ -39,8 +39,8 @@ public abstract class EditGameRulesScreen$RuleListWidgetMixin extends ElementLis
 	@SuppressWarnings("UnresolvedMixinReference")
 	@Inject(method = "method_27638(Ljava/util/Map$Entry;)V", at = @At("HEAD"), cancellable = true)
 	private void dontShowFabric(Map.Entry<GameRules.RuleKey<?>, EditGameRulesScreen.AbstractRuleWidget> entry, CallbackInfo ci) {
-		if (GameRuleRegistry.MAP.containsKey(entry.getKey())) {
-			FabricGameRuleCategory category = GameRuleRegistry.MAP.get(entry.getKey());
+		if (RuleCategories.containsKey(entry.getKey())) {
+			FabricGameRuleCategory category = RuleCategories.get(entry.getKey());
 			fabricCategories.putIfAbsent(category, new ArrayList<>());
 			fabricCategories.get(category).add(entry.getValue());
 			ci.cancel();

--- a/src/main/java/io/github/fablabsmc/fablabs/mixin/gamerule/client/EditGameRulesScreen$RuleListWidgetMixin.java
+++ b/src/main/java/io/github/fablabsmc/fablabs/mixin/gamerule/client/EditGameRulesScreen$RuleListWidgetMixin.java
@@ -42,7 +42,7 @@ public abstract class EditGameRulesScreen$RuleListWidgetMixin extends ElementLis
 		if (RuleCategories.containsKey(entry.getKey())) {
 			FabricGameRuleCategory category = RuleCategories.get(entry.getKey());
 			fabricCategories.putIfAbsent(category, new ArrayList<>());
-			fabricCategories.get(category).add(entry.getValue());
+			fabricCategories.computeIfAbsent(category, c -> new ArrayList<>()).add(entry.getValue());
 			ci.cancel();
 		}
 	}

--- a/src/main/resources/mixins.gamerule-api.json
+++ b/src/main/resources/mixins.gamerule-api.json
@@ -5,8 +5,8 @@
   "mixins": [
     "GameRuleCommandAccessor",
     "GameRuleCommandMixin$RuleConsumer",
-    "GameRules$BooleanRuleAccessor",
     "GameRules$IntRuleAccessor",
+    "GameRules$BooleanRuleAccessor",
     "GameRulesAccessor"
   ],
   "client": [

--- a/src/main/resources/mixins.gamerule-api.json
+++ b/src/main/resources/mixins.gamerule-api.json
@@ -5,12 +5,13 @@
   "mixins": [
     "GameRuleCommandAccessor",
     "GameRuleCommandMixin$RuleConsumer",
-    "GameRules$IntRuleAccessor",
     "GameRules$BooleanRuleAccessor",
+    "GameRules$IntRuleAccessor",
     "GameRulesAccessor"
   ],
   "client": [
     "client.EditGameRulesScreen$RuleListWidget$RuleTypeConsumerMixin",
+    "client.EditGameRulesScreen$RuleListWidgetMixin",
     "client.EditGameRulesScreenAccessor",
     "client.ScreenAccessor"
   ],


### PR DESCRIPTION
Using only one new class and some minor changes to `GameRuleRegistry`, users can now register custom categories to be displayed on the GameRules screen when creating a new world.